### PR TITLE
feat: initial implementation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+tap-snapshots
+node_modules
+modules
+test
+dist
+tmp

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,23 @@
+{
+    "env": {
+        "es6": true,
+        "node": true,
+        "browser": true
+    },
+    "extends": "airbnb-base",
+    "rules": {
+        "import/extensions": [0, "always"],
+        "strict": [0, "global"],
+        "prefer-const": 1,
+        "indent": [1, 4],
+        "class-methods-use-this": [0],
+        "import/no-extraneous-dependencies": [0],
+        "arrow-body-style": [0, "always"],
+        "no-multiple-empty-lines": [0],
+        "no-underscore-dangle": [0],
+        "comma-dangle": [0],
+        "no-plusplus": [0],
+        "no-console": [0],
+        "new-cap": [0]
+    }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Release and Publish
+
+on:
+ pull_request:
+ push:
+  branches: [ master ]
+
+jobs:
+ test:
+  runs-on: ubuntu-latest
+  steps:
+  - name: Checkout
+    uses: actions/checkout@v2
+  - name: Setup Node.js
+    uses: actions/setup-node@v1
+    with:
+      node-version: 14.x
+  - name: npm install
+    run: |
+      npm install
+  - name: npm lint
+    run: |
+      npm run lint
+  - name: npm test
+    run: |
+      npm test
+ release:
+  if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+  runs-on: ubuntu-latest
+  needs: [test]
+  steps:
+  - name: Checkout
+    uses: actions/checkout@v2
+  - name: Setup Node.js
+    uses: actions/setup-node@v1
+    with:
+      node-version: 14.x
+  - name: npm install
+    run: |
+      npm install
+  - name: npx semantic-release
+    run: |
+      npx semantic-release
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Run Lint and Tests
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node-version: [14.x, 15.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install
+        run: |
+          npm install
+        env:
+          CI: true
+      - name: Run tests
+        run: |
+          npm test
+        env:
+          CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+node_modules/**/*
+.DS_Store
+tmp/**/*
+.idea
+.idea/**/*
+*.iml
+*.log
+package-lock.json
+.nyc_output
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+tap-snapshots
+node_modules
+.nyc_output
+modules
+test
+*.log
+*.png
+*.svg
+.gitignore
+.npmignore
+.eslintrc
+.eslintignore
+.travis.yml
+rollup.config.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -1,1 +1,141 @@
 # rollup-plugin-import-map
+
+Rollup plugin to apply [import map](https://github.com/WICG/import-maps#multiple-import-map-support) mapping to ECMAScript modules (ESM) ahead of time.
+
+## Installation
+
+```bash
+$ npm install rollup-plugin-import-map
+```
+
+## Usage
+
+```js
+import importMapPlugin from "rollup-plugin-import-map";
+
+const map = {
+    imports: {
+        'lit-element': 'https://cdn.eik.dev/lit-element/v2'
+    }
+};
+
+export default {
+  input: "source/main.js",
+  plugins: [importMapPlugin(map)],
+  output: {
+    file: "build.js",
+    format: "esm",
+  },
+};
+```
+
+## Description
+
+This plugin transform import specifiers in ESM based on a mapping defined in one or multiple [import map(s)](https://github.com/WICG/import-maps#multiple-import-map-support). Import maps is a suggested specification to be implemented in browsers but they can be used to apply mapping ahead of time. This module does so.
+
+One use case for import maps is to transform ESM bare import statements to an import statement which is an absolute URL to the same module on a CDN.
+
+Lets say we have the following in our ESM when developing locally with node.js:
+
+```js
+import {html, render} from 'lit-html';
+```
+
+Then on build we can apply the following import map:
+
+```js
+{
+  "imports": {
+    "lit-html": "https://cdn.eik.dev/npm/lit-html/v1/lit-html.js",
+  }
+}
+```
+
+When applied, our output wil be:
+
+```js
+import * as lit from 'https://cdn.eik.dev/npm/lit-html/v1/lit-html.js'
+```
+
+## API
+
+The API of the plugin is fairly simple. The plugin can take one import map or an array of import maps.
+
+One import map:
+
+```js
+export default {
+  input: "source/main.js",
+  plugins: [importMapPlugin({ ... })],
+  output: {
+    file: "build.js",
+    format: "esm",
+  },
+};
+```
+
+Array of import maps:
+
+```js
+export default {
+  input: "source/main.js",
+  plugins: [importMapPlugin([
+      { ... },
+      { ... },
+      { ... },
+  ])],
+  output: {
+    file: "build.js",
+    format: "esm",
+  },
+};
+```
+
+When an array of import maps is provided and multiple import maps is set of map the same import specifier, the last import specifies in the array will be the one which is applied during transformation.
+
+## Note on the rollup external option
+
+Any mappings defined by any of the means described above must not occur in the Rollup `external` option.
+If so, this module will throw.
+
+In other words, this will not work:
+
+```js
+export default {
+  input: "source/main.js",
+  external: ["lit-element"],
+  plugins: [
+    importMapPlugin({
+      imports: {
+        'lit-element': 'https://cdn.eik.dev/lit-element/v2'
+      },
+    }),
+  ],
+  output: {
+    file: "build.js",
+    format: "esm",
+  },
+};
+```
+
+## License
+
+Copyright (c) 2020 Trygve Lie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,0 +1,54 @@
+const isBare = (str) => {
+    if (str.startsWith('/') || str.startsWith('./') || str.startsWith('../') || str.substr(0, 7) === 'http://' || str.substr(0, 8) === 'https://') {
+        return false;
+    }
+    return true;
+};
+
+const builder = (options, cache, map) => {
+    Object.keys(map.imports).forEach((key) => {
+        const value = map.imports[key];
+
+        if (isBare(value)) {
+            throw Error(`Import specifier can NOT be mapped to a bare import statement. Import specifier "${key}" is being wrongly mapped to "${value}"`);
+        }
+
+        if (typeof options.external === 'function') {
+            if (options.external(key)) throw Error('Import specifier must NOT be present in the Rollup external config. Please remove specifier from the Rollup external config.');
+        }
+
+        if (Array.isArray(options.external)) {
+            if (options.external.includes(key)) throw Error('Import specifier must NOT be present in the Rollup external config. Please remove specifier from the Rollup external config.');
+        }
+
+        cache.set(key, value);
+    });
+};
+
+export default function rollupImportMapPlugin(maps = []) {
+    const cache = new Map();
+    return {
+        name: 'rollup-plugin-import-map',
+
+        buildStart(options) {
+            if (Array.isArray(maps)) {
+                maps.forEach((map) => {
+                    builder(options, cache, map);
+                });
+                return;
+            }
+            builder(options, cache, maps);
+        },
+
+        resolveId(importee) {
+            const url = cache.get(importee);
+            if (url) {
+                return {
+                    id: url,
+                    external: true
+                };
+            }
+            return null;
+        }
+    };
+}

--- a/modules/basic/main.js
+++ b/modules/basic/main.js
@@ -1,0 +1,6 @@
+import { html } from 'lit-element';
+
+const render = (world) => {
+    return html`<p>Hello ${world}!</p>`;
+};
+render();

--- a/modules/file/main.js
+++ b/modules/file/main.js
@@ -1,0 +1,13 @@
+import { html } from 'lit-html/lit-html';
+import { css } from 'lit-html';
+import { LitElement } from 'lit-element';
+
+export default class Inner extends LitElement {
+    static get styles() {
+        return [css`:host { color: red; }`];
+    }
+
+    render(world) {
+        return html`<p>Hello ${world}!</p>`;
+    }
+}

--- a/modules/simple/app/app.js
+++ b/modules/simple/app/app.js
@@ -1,0 +1,21 @@
+import { replaceElement } from '../utils/dom.js';
+import view from './views.js';
+import data from '../data/data.js';
+
+export default class App {
+    constructor(root) {
+        this.root = root;
+    }
+
+    render() {
+        const items = data();
+        const el = view(items);
+        this.root = replaceElement(this.root, el);
+    }
+
+    update() {
+        setInterval(() => {
+            this.render();
+        }, 1000);
+    }
+}

--- a/modules/simple/app/views.js
+++ b/modules/simple/app/views.js
@@ -1,0 +1,5 @@
+import { html, css } from 'lit-element';
+
+export default function view(items) {
+    return html`<p>Hello ${items[0]}!</p>`;
+}

--- a/modules/simple/data/data.js
+++ b/modules/simple/data/data.js
@@ -1,0 +1,13 @@
+function random(min, max) {
+    return Math.floor(min + Math.random() * (max + 1 - min));
+}
+
+export default function data() {
+    return [
+        random(0, 20),
+        random(20, 40),
+        random(40, 60),
+        random(60, 80),
+        random(80, 100),
+    ];
+}

--- a/modules/simple/main.js
+++ b/modules/simple/main.js
@@ -1,0 +1,19 @@
+import { firstElement } from './utils/dom.js';
+import App from './app/app.js';
+
+const ready = () => {
+    return new Promise((resolve) => {
+        document.addEventListener('DOMContentLoaded', () => {
+            const el = document.getElementById('app');
+            resolve(firstElement(el));
+        });
+    });
+};
+
+const start = async () => {
+    const el = await ready();
+    const app = new App(el);
+    app.render();
+    app.update();
+};
+start();

--- a/modules/simple/utils/dom.js
+++ b/modules/simple/utils/dom.js
@@ -1,0 +1,8 @@
+export function replaceElement(target, element) {
+    target.replaceWith(element);
+    return element;
+}
+
+export function firstElement(element) {
+    return element.firstElementChild;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "rollup-plugin-import-map",
+  "version": "1.0.0",
+  "description": "Rollup plugin to apply import map mappings to a build",
+  "main": "lib/plugin.js",
+  "type": "module",
+  "scripts": {
+    "test": "tap --no-esm test/*.js --no-coverage",
+    "test:snapshot": "TAP_SNAPSHOT=1 tap --no-esm test/*.js --no-coverage",
+    "lint": "eslint . --ext=js",
+    "lint:fix": "eslint . --fix --ext=js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/trygve-lie/rollup-plugin-import-map.git"
+  },
+  "keywords": [
+    "Rollup",
+    "Import",
+    "Map",
+    "ESM",
+    "Modules",
+    "ECMAScript"
+  ],
+  "author": "Trygve Lie",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/trygve-lie/rollup-plugin-import-map/issues"
+  },
+  "homepage": "https://github.com/trygve-lie/rollup-plugin-import-map#readme",
+  "devDependencies": {
+    "@semantic-release/changelog": "5.0.1",
+    "@semantic-release/commit-analyzer": "8.0.1",
+    "@semantic-release/git": "9.0.0",
+    "@semantic-release/github": "7.2.0",
+    "@semantic-release/npm": "7.0.8",
+    "@semantic-release/release-notes-generator": "9.0.1",
+    "eslint": "7.14.0",
+    "eslint-config-airbnb-base": "14.2.1",
+    "eslint-plugin-import": "2.22.1",
+    "rollup": "2.33.3",
+    "semantic-release": "17.3.0",
+    "tap": "14.11.0"
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "extends": [
+    "config:base",
+    "group:linters"
+  ],
+  "packageRules": [{
+    "depTypeList": ["dependencies"],
+    "automerge": true,
+    "major": {
+      "automerge": false
+    }
+  },
+  {
+    "depTypeList": ["devDependencies"],
+    "schedule": ["before 4am on monday"],
+    "commitMessage": "Dev dependency {{depName}} updated to version {{newValue}}",
+    "prTitle": "Dev dependency update: {{depName}}",
+    "automerge": true,
+    "major": {
+      "automerge": false
+    }
+  }]
+}

--- a/tap-snapshots/package.json
+++ b/tap-snapshots/package.json
@@ -1,0 +1,1 @@
+{"type": "commonjs"}

--- a/tap-snapshots/test-plugin.js-TAP.test.js
+++ b/tap-snapshots/test-plugin.js-TAP.test.js
@@ -1,0 +1,297 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/plugin.js TAP plugin() - array of import map maps - should replace import statements with CDN URLs > non bare imports 1`] = `
+import { firstElement } from 'https://cdn.pika.dev/something/v666';
+import { html } from 'https://cdn.pika.dev/lit-element/v2';
+
+function replaceElement(target, element) {
+    target.replaceWith(element);
+    return element;
+}
+
+function view(items) {
+    return html\`<p>Hello \${items[0]}!</p>\`;
+}
+
+function random(min, max) {
+    return Math.floor(min + Math.random() * (max + 1 - min));
+}
+
+function data() {
+    return [
+        random(0, 20),
+        random(20, 40),
+        random(40, 60),
+        random(60, 80),
+        random(80, 100),
+    ];
+}
+
+class App {
+    constructor(root) {
+        this.root = root;
+    }
+
+    render() {
+        const items = data();
+        const el = view(items);
+        this.root = replaceElement(this.root, el);
+    }
+
+    update() {
+        setInterval(() => {
+            this.render();
+        }, 1000);
+    }
+}
+
+const ready = () => {
+    return new Promise((resolve) => {
+        document.addEventListener('DOMContentLoaded', () => {
+            const el = document.getElementById('app');
+            resolve(firstElement(el));
+        });
+    });
+};
+
+const start = async () => {
+    const el = await ready();
+    const app = new App(el);
+    app.render();
+    app.update();
+};
+start();
+
+`
+
+exports[`test/plugin.js TAP plugin() - basic module - should replace lit-element with CDN URL > basic example 1`] = `
+import { html } from 'https://cdn.pika.dev/lit-element/v2';
+
+const render = (world) => {
+    return html\`<p>Hello \${world}!</p>\`;
+};
+render();
+
+`
+
+exports[`test/plugin.js TAP plugin() - import map maps address to a relative path - should replace import statement with relative path > non bare imports 1`] = `
+import { html } from './lit-element/v2';
+
+function replaceElement(target, element) {
+    target.replaceWith(element);
+    return element;
+}
+
+function firstElement(element) {
+    return element.firstElementChild;
+}
+
+function view(items) {
+    return html\`<p>Hello \${items[0]}!</p>\`;
+}
+
+function random(min, max) {
+    return Math.floor(min + Math.random() * (max + 1 - min));
+}
+
+function data() {
+    return [
+        random(0, 20),
+        random(20, 40),
+        random(40, 60),
+        random(60, 80),
+        random(80, 100),
+    ];
+}
+
+class App {
+    constructor(root) {
+        this.root = root;
+    }
+
+    render() {
+        const items = data();
+        const el = view(items);
+        this.root = replaceElement(this.root, el);
+    }
+
+    update() {
+        setInterval(() => {
+            this.render();
+        }, 1000);
+    }
+}
+
+const ready = () => {
+    return new Promise((resolve) => {
+        document.addEventListener('DOMContentLoaded', () => {
+            const el = document.getElementById('app');
+            resolve(firstElement(el));
+        });
+    });
+};
+
+const start = async () => {
+    const el = await ready();
+    const app = new App(el);
+    app.render();
+    app.update();
+};
+start();
+
+`
+
+exports[`test/plugin.js TAP plugin() - import map maps non bare imports - should replace import statement with CDN URL > non bare imports 1`] = `
+import { firstElement } from 'https://cdn.pika.dev/something/v666';
+import { html } from 'https://cdn.pika.dev/lit-element/v2';
+
+function replaceElement(target, element) {
+    target.replaceWith(element);
+    return element;
+}
+
+function view(items) {
+    return html\`<p>Hello \${items[0]}!</p>\`;
+}
+
+function random(min, max) {
+    return Math.floor(min + Math.random() * (max + 1 - min));
+}
+
+function data() {
+    return [
+        random(0, 20),
+        random(20, 40),
+        random(40, 60),
+        random(60, 80),
+        random(80, 100),
+    ];
+}
+
+class App {
+    constructor(root) {
+        this.root = root;
+    }
+
+    render() {
+        const items = data();
+        const el = view(items);
+        this.root = replaceElement(this.root, el);
+    }
+
+    update() {
+        setInterval(() => {
+            this.render();
+        }, 1000);
+    }
+}
+
+const ready = () => {
+    return new Promise((resolve) => {
+        document.addEventListener('DOMContentLoaded', () => {
+            const el = document.getElementById('app');
+            resolve(firstElement(el));
+        });
+    });
+};
+
+const start = async () => {
+    const el = await ready();
+    const app = new App(el);
+    app.render();
+    app.update();
+};
+start();
+
+`
+
+exports[`test/plugin.js TAP plugin() - import specifier is a interior package path - should replace with CDN URL > interior package path 1`] = `
+import { html } from 'https://cdn.pika.dev/lit-html/v2';
+import { css } from 'https://cdn.pika.dev/lit-html/v1';
+import { LitElement } from 'https://cdn.pika.dev/lit-element/v2';
+
+class Inner extends LitElement {
+    static get styles() {
+        return [css\`:host { color: red; }\`];
+    }
+
+    render(world) {
+        return html\`<p>Hello \${world}!</p>\`;
+    }
+}
+
+export default Inner;
+
+`
+
+exports[`test/plugin.js TAP plugin() - simple module - should replace lit-element with CDN URL > simple example 1`] = `
+import { html } from 'https://cdn.pika.dev/lit-element/v2';
+
+function replaceElement(target, element) {
+    target.replaceWith(element);
+    return element;
+}
+
+function firstElement(element) {
+    return element.firstElementChild;
+}
+
+function view(items) {
+    return html\`<p>Hello \${items[0]}!</p>\`;
+}
+
+function random(min, max) {
+    return Math.floor(min + Math.random() * (max + 1 - min));
+}
+
+function data() {
+    return [
+        random(0, 20),
+        random(20, 40),
+        random(40, 60),
+        random(60, 80),
+        random(80, 100),
+    ];
+}
+
+class App {
+    constructor(root) {
+        this.root = root;
+    }
+
+    render() {
+        const items = data();
+        const el = view(items);
+        this.root = replaceElement(this.root, el);
+    }
+
+    update() {
+        setInterval(() => {
+            this.render();
+        }, 1000);
+    }
+}
+
+const ready = () => {
+    return new Promise((resolve) => {
+        document.addEventListener('DOMContentLoaded', () => {
+            const el = document.getElementById('app');
+            resolve(firstElement(el));
+        });
+    });
+};
+
+const start = async () => {
+    const el = await ready();
+    const app = new App(el);
+    app.render();
+    app.update();
+};
+start();
+
+`

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,0 +1,176 @@
+import plugin from '../lib/plugin.js';
+import { rollup } from 'rollup';
+import path from 'path';
+import url from 'url';
+import tap from 'tap';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const simple = `${__dirname}/../modules/simple/main.js`;
+const basic = `${__dirname}/../modules/basic/main.js`;
+const file = `${__dirname}/../modules/file/main.js`;
+
+/*
+ * When running tests on Windows, the output code get some extra \r on each line.
+ * Remove these so snapshots work on all OSes.
+ */
+const clean = str => str.split('\r').join('');
+
+tap.test('plugin() - target is refered to in external - should reject process', (t) => {
+    const options = {
+        input: simple,
+        external: ['foo'],
+        plugins: [plugin({
+            imports: {
+                'foo': 'http://not.a.host.com'
+            }
+        })],
+    }
+    t.rejects(rollup(options), new Error('Import specifier must NOT be present in the Rollup external config. Please remove specifier from the Rollup external config.'));
+    t.end();
+});
+
+
+tap.test('plugin() - basic module - should replace lit-element with CDN URL', async (t) => {
+    const options = {
+        input: basic,
+        onwarn: (warning, warn) => {
+            // Supress logging
+        },
+        plugins: [plugin({
+            imports: {
+                'lit-element': 'https://cdn.pika.dev/lit-element/v2'
+            }
+        })],
+    }
+
+    const bundle = await rollup(options);
+    const { output } = await bundle.generate({ format: 'esm' });
+
+    t.matchSnapshot(clean(output[0].code), 'basic example');
+    t.end();
+});
+
+tap.test('plugin() - simple module - should replace lit-element with CDN URL', async (t) => {
+    const options = {
+        input: simple,
+        onwarn: (warning, warn) => {
+            // Supress logging
+        },
+        plugins: [plugin({
+            imports: {
+                'lit-element': 'https://cdn.pika.dev/lit-element/v2'
+            }
+        })],
+    }
+
+    const bundle = await rollup(options);
+    const { output } = await bundle.generate({ format: 'esm' });
+
+    t.matchSnapshot(clean(output[0].code), 'simple example');
+    t.end();
+});
+
+tap.test('plugin() - import map maps non bare imports - should replace import statement with CDN URL', async (t) => {
+    const options = {
+        input: simple,
+        onwarn: (warning, warn) => {
+            // Supress logging
+        },
+        plugins: [plugin({
+            imports: {
+                'lit-element': 'https://cdn.pika.dev/lit-element/v2',
+                './utils/dom.js': 'https://cdn.pika.dev/something/v666'
+            }
+        })],
+    }
+
+    const bundle = await rollup(options);
+    const { output } = await bundle.generate({ format: 'esm' });
+
+    t.matchSnapshot(clean(output[0].code), 'non bare imports');
+    t.end();
+});
+
+tap.test('plugin() - import map maps address to a relative path - should replace import statement with relative path', async (t) => {
+    const options = {
+        input: simple,
+        onwarn: (warning, warn) => {
+            // Supress logging
+        },
+        plugins: [plugin({
+            imports: {
+                'lit-element': './lit-element/v2',
+            }
+        })],
+    }
+
+    const bundle = await rollup(options);
+    const { output } = await bundle.generate({ format: 'esm' });
+
+    t.matchSnapshot(clean(output[0].code), 'non bare imports');
+    t.end();
+});
+
+tap.test('plugin() - import specifier is a interior package path - should replace with CDN URL', async (t) => {
+    const options = {
+        input: file,
+        onwarn: (warning, warn) => {
+            // Supress logging
+        },
+        plugins: [plugin({
+            imports: {
+                'lit-element': 'https://cdn.pika.dev/lit-element/v2',
+                'lit-html/lit-html': 'https://cdn.pika.dev/lit-html/v2',
+                'lit-html': 'https://cdn.pika.dev/lit-html/v1',
+            }
+        })],
+    }
+
+    const bundle = await rollup(options);
+    const { output } = await bundle.generate({ format: 'esm' });
+
+    t.matchSnapshot(clean(output[0].code), 'interior package path');
+    t.end();
+});
+
+tap.test('plugin() - import map maps address to a bare importer - should throw', async (t) => {
+    const options = {
+        input: simple,
+        onwarn: (warning, warn) => {
+            // Supress logging
+        },
+        plugins: [plugin({
+            imports: {
+                'lit-element': 'lit-element/v2',
+            }
+        })],
+    }
+    
+    t.rejects(rollup(options), new Error('Import specifier can NOT be mapped to a bare import statement. Import specifier "lit-element" is being wrongly mapped to "lit-element/v2"'));
+    t.end();
+});
+
+tap.test('plugin() - array of import map maps - should replace import statements with CDN URLs', async (t) => {
+    const options = {
+        input: simple,
+        onwarn: (warning, warn) => {
+            // Supress logging
+        },
+        plugins: [plugin([{
+            imports: {
+                'lit-element': 'https://cdn.pika.dev/lit-element/v2'
+            }
+        },
+        {
+            imports: {
+                './utils/dom.js': 'https://cdn.pika.dev/something/v666'
+            }
+        }])],
+    }
+
+    const bundle = await rollup(options);
+    const { output } = await bundle.generate({ format: 'esm' });
+
+    t.matchSnapshot(clean(output[0].code), 'non bare imports');
+    t.end();
+});


### PR DESCRIPTION
Initial implementation of a Rollup plugin to apply import maps to ESM during build.

Usage is as follow:

```js
import importMapPlugin from "rollup-plugin-import-map";
const map = {
    imports: {
        'lit-element': 'https://cdn.eik.dev/lit-element/v2'
    }
};
export default {
  input: "source/main.js",
  plugins: [importMapPlugin(map)],
  output: {
    file: "build.js",
    format: "esm",
  },
};
```