### PR TITLE
ci: Rename master to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Release and Publish
 on:
  pull_request:
  push:
-  branches: [ master ]
+  branches: [ main ]
 
 jobs:
  test:
@@ -25,7 +25,7 @@ jobs:
     run: |
       npm test
  release:
-  if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
   runs-on: ubuntu-latest
   needs: [test]
   steps:


### PR DESCRIPTION
New repos in github is named `main`. Clean up some cut and paste code to reference `main` instead of the old `master`.